### PR TITLE
Look up cards.default_parameters path and files dynamically

### DIFF
--- a/src/picnic/cards/__init__.py
+++ b/src/picnic/cards/__init__.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def get_path_to_jsons():
+    """
+    Locate the default_parameters json files and return a Path to them.
+    """
+
+    return Path(__file__).parent.absolute() / "default_parameters"
+
+
+def get_path_to_json(keyword):
+    """
+    Locate a specific default_parameters json file and return a Path to it.
+    """
+
+    return get_path_to_jsons() / f"{keyword}.json"

--- a/src/picnic/input_deck_reader.py
+++ b/src/picnic/input_deck_reader.py
@@ -7,14 +7,14 @@ import os
 import json
 import string
 import logging
-from pathlib import Path
+
+from picnic.cards import get_path_to_json
+
 
 # =======================================
 # Constants
 INPUT_DECK_EXTENSION = '.inp'
 commenter = '#'
-# default_jsons_path = "cards/default_parameters"
-
 
 # =======================================
 # Classes
@@ -209,7 +209,7 @@ class Card():
         else:
             raise TypeError('Error: Unexpected data type passed to Card.parameters must be a tuple or dict')
             
-    def _load_defaults(self, defaults_path=None):
+    def _load_defaults(self):
         """
         Set aside in a method so we can change the json if necessary
 
@@ -218,18 +218,8 @@ class Card():
             default values are stored
         """
 
-        # path of the json file
-        if defaults_path is None:
-            defaults_path = (
-                    Path(__file__).parent.absolute() /
-                    "cards" / "default_parameters"
-            )
-        json_path = os.path.join(
-            defaults_path,
-            self.cardname[1:].replace(' ', '_')+'.json'
-        )
-
-        # load the json
+        # Load the json
+        json_path = get_path_to_json(self.cardname[1:].replace(' ', '_'))
         with open(json_path, 'r') as f:
             data = json.load(f)
 
@@ -337,12 +327,14 @@ class Card():
                     self._datalines.append([itm.strip() for itm in l.strip().split(',')])
         else:
             raise InputDeckSyntaxError('Error: Unexpected data type when setting dataline for card ' + self.cardname)
-        
+
+
 class InputDeckSyntaxError(Exception):
     """
     Custom error to trap input deck specific errors
     """
     pass
+
 
 # =======================================
 # Functions
@@ -356,6 +348,7 @@ def check_file_extension(filename, extension):
     """
     return os.path.splitext(filename)[-1].lower() == extension
 
+
 def check_file_exists(filename):
     """
     Check that the file exists where the user thinks it does
@@ -364,6 +357,7 @@ def check_file_exists(filename):
       -. `filename` : str, the input deck file
     """
     return os.path.exists(filename)
+
 
 def read_parameter_card(all_the_parameter_lines):
     r"""
@@ -382,20 +376,13 @@ def read_parameter_card(all_the_parameter_lines):
     del all_the_parameter_lines
     return locals()
     
-def load_default_parameter_json(keyword, json_path):
-    """
-    Load in the default options provided by the json file keyword = str; 'pet'
-    json_path = filepath; 'static/default_parameters'
-    """
-    print(keyword + '\n\t' + json_path)
-    return json.loads(os.path.join(json_path, keyword.replace(' ', '_')+'.json'))[keyword]
-
 
 def read_input_deck(input_deck):
     """
     A function that will call the InputDeck class and fill it given a file
     """
     return InputDeck(input_deck)
+
 
 def make_card(cardname, parameters=None, datalines=None):
     """
@@ -421,6 +408,7 @@ def make_card(cardname, parameters=None, datalines=None):
         for line in datalines:
             card.add_dataline(line)
     return card
+
 
 # =======================================
 # Main

--- a/src/picnic/pantry.py
+++ b/src/picnic/pantry.py
@@ -6,10 +6,8 @@ import os
 import PySimpleGUI as sg
 import base64
 import tempfile
-import glob
 import importlib
 from io import BytesIO
-from pathlib import Path
 
 from PIL import (
     Image,
@@ -17,8 +15,8 @@ from PIL import (
     ImageFont
 )
 
-# from picnic.input_deck_reader import read_input_deck, make_card
-from input_deck_reader import (
+from picnic.cards import get_path_to_jsons
+from picnic.input_deck_reader import (
     read_input_deck,
     make_card
 )
@@ -59,12 +57,6 @@ THEME_IDX = 0
 
 PADDING = 4
 CARD_SIZE = (780, 116)
-
-DEFAULT_JSONS_PATH = os.path.join(
-    Path(__file__).parent.absolute(),
-    'cards',
-    'default_parameters'
-)
 
 FOOTER_BUTTON_SIZE = (17, 2)
 
@@ -406,7 +398,7 @@ def add_card_manually():
         [
             sg.T('Add Preprocessing Step'),
             sg.Combo(
-                list(get_card_list(DEFAULT_JSONS_PATH).keys()),
+                list(get_card_list(get_path_to_jsons()).keys()),
                 key = '-COMBO-'
             )
         ],
@@ -607,7 +599,7 @@ def create_variable_window(variables):
             window.Close()
             return None
     
-def get_card_list(folder_path=DEFAULT_JSONS_PATH, extension='.json'):
+def get_card_list(folder_path=None, extension='.json'):
     """
     return a list of cards found in the `cards.default_parameters`
     sub-directory. We use this to determine which instances steps will be
@@ -620,13 +612,15 @@ def get_card_list(folder_path=DEFAULT_JSONS_PATH, extension='.json'):
     :Return:
       -. a dictionary, cards and their associated picnic classes
     """
+
     # {key = 'card name' : val = CardName obj}
     # example {'camra' : picnic.cards.camra.Camra}
     card_instance_legend = {}
 
-    # get all the jsons in the default parameters folder
-    all_jsons = glob.glob(os.path.join(folder_path, '*' + extension))
-    for json_ in all_jsons:
+    # Get all the jsons in the default parameters folder
+    if folder_path is None:
+        folder_path = get_path_to_jsons()
+    for json_ in folder_path.glob(f"*{extension}"):
         card_name = os.path.basename(json_).replace(extension, '').replace('_', ' ')
         module_ = importlib.import_module(
             # '.'.join(('picnic', 'cards', card_name.replace(' ', '_')))


### PR DESCRIPTION
Ignore the "restore..." comment on this pull request. It was left over from the last one and I missed changing it.

After reviewing the [setuptools installation process](https://setuptools.pypa.io/en/latest/userguide/datafiles.html) and a [stackoverflow answer](https://stackoverflow.com/a/5423147/2846766), I added two very simple functions to handle the lookup in `cards/__init__.py`.

I import one at a the top of `input_deck_reader.py`, and I've simplified `Card._load_defaults` to use it. I also deleted a `load_default_parameter_json` function from `input_deck_reader.py` that was not being used.

I import one at the top of `pantry.py`, and I simplified its `get_card_list` function to use it.
