### PR TITLE
update SPM and replace PySimpleGUI with FreeSimpleGUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,9 @@ FROM downloader AS spm
 # These args are repeated in the final image, so make changes in both places.
 ARG MATLAB_VERSION=R2024b
 ARG AGREE_TO_MATLAB_RUNTIME_LICENSE=yes
-ARG SPM_VERSION=24
-ARG SPM_RELEASE=24.10
-ARG SPM_REVISION=alpha22
+ARG SPM_VERSION=25
+ARG SPM_RELEASE=${SPM_VERSION}.01
+ARG SPM_REVISION=02
 ENV SPM_TAG=${SPM_RELEASE}${SPM_REVISION:+.${SPM_REVISION}}
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 /_build
 /doctrees
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib~=3.8
 pandas~=2.2
 # Independent of yml file
 setuptools~=75.8.0
-PySimpleGUI~=4.70.1
+FreeSimpleGUI~=5.2.0.post1
 pillow~=11.1.0
 nibabel~=5.3.2
 nipype~=1.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = picnic
-version = 0.1.3
+version = 0.1.4
 author = Eric Hauser
 author_email = eric.hauser@nyspi.columbia.edu
 maintainer = Mike Schmidt

--- a/src/picnic/pantry.py
+++ b/src/picnic/pantry.py
@@ -3,7 +3,7 @@
 # =======================================
 # Imports
 import os
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import base64
 import tempfile
 import importlib
@@ -105,7 +105,7 @@ class Deck():
         build the canvas for which to draw
 
         :Parameters:
-          -. `graph` : PySimpleGUI.Graph element, the graph to be drawn on
+          -. `graph` : FreeSimpleGUI.Graph element, the graph to be drawn on
           -. `depressed` : int, clicking on a button changes the color
         """
         # clear the graph
@@ -247,8 +247,8 @@ def create_main_window(deck, theme, window=None):
 
     :Parameters:
       -. `deck` : input_deck_reader.InputDeck obj, a picnic input deck
-      -. `theme` : str, a PySimpleGUI default color
-      -. `window` : PySimpleGUI.Window, if one already exists, overwrite it
+      -. `theme` : str, a FreeSimpleGUI default color
+      -. `window` : FreeSimpleGUI.Window, if one already exists, overwrite it
     """
     # set the theme, this can be changed from the menubar
     sg.theme(theme)


### PR DESCRIPTION
@Eric, When I updated to FreeSimpleGUI, I had to pick a new version, too. They didn't fork back before 5.0.0.

When I built the next docker container, it failed because SPM does not maintain the 24.10 version we were using on github. I guess it aged out. So I updated that to the latest 25.01.02 and the container (0.1.4) built successfully. I have not tested it, but I'll test it out soon to ensure SPM still works.